### PR TITLE
add: Redis SET-based history filtering with dual method approach

### DIFF
--- a/src/recommendation/core/engine.py
+++ b/src/recommendation/core/engine.py
@@ -360,7 +360,6 @@ class RecommendationEngine:
         try:
             # Initialize location candidate manager if not already done
             if not hasattr(self, "location_manager"):
-
                 self.location_manager = LocationCandidateManager(
                     valkey_config=self.config.valkey_config
                 )
@@ -617,12 +616,18 @@ class RecommendationEngine:
                     del mixer_output[key]
 
         # for testing realtime exclusion of watched items/ dedup/ reported items
-        mixer_output["recommendations"] += [
-            # "v1",
-            # "v2",
-            # "v3",
-            "08f21eacddf1409495dd0dfb368cf067",
-        ]
+        # append test videos first so that we can quickly test the filtering logic
+        """
+        # for debugging purposes
+        mixer_output["recommendations"] = [
+            "video_nsfw_001",
+            "video_nsfw_002",
+            "video_watched_nsfw_456",
+            "video_test_clean",
+        ] + mixer_output["recommendations"]
+
+        logger.info(f"Mixer output without filtering:\n\n {mixer_output}")
+        """
 
         # remove items from the generic exclusion list
         mixer_output["recommendations"] = self._filter_excluded_items(
@@ -686,6 +691,7 @@ class RecommendationEngine:
             # todo: this needs special attention based on redis migration
             # exclude_watched_items=exclude_watched_items,
         )
+        # logger.info(f"Filtered recommendations:\n\n {filtered_recommendations}")
         filter_time = (datetime.datetime.now() - filter_start).total_seconds()
         logger.info(f"Watched items filtering completed in {filter_time:.2f} seconds")
 
@@ -753,7 +759,7 @@ class RecommendationEngine:
             old_total_results = len(recommendations["posts"])
             recommendations["posts"] = recommendations["posts"][:num_results]
             logger.info(
-                f"Trimmed results to from {old_total_results} -> {min(old_total_results,num_results)} items as requested"
+                f"Trimmed results to from {old_total_results} -> {min(old_total_results, num_results)} items as requested"
             )
 
         total_time = (datetime.datetime.now() - start_time).total_seconds()

--- a/src/recommendation/core/fallback_engine.py
+++ b/src/recommendation/core/fallback_engine.py
@@ -53,6 +53,20 @@ class FallbackRecommendationEngine(RecommendationEngine):
             "fallback_recommendations": fallback_recommendations,
         }
         """
+
+        # For testing realtime exclusion of watched items in cache endpoint
+        # Append test videos first so that we can quickly test the filtering logic
+        """
+        # for debugging purposes
+        fallback_recommendations["fallback_recommendations"] = [
+            "video_nsfw_001",
+            "video_nsfw_002",
+            "video_watched_nsfw_456",
+            "video_test_clean",
+        ] + fallback_recommendations["fallback_recommendations"]
+
+        logger.info(f"Fallback output before filtering:\n\n {fallback_recommendations}")
+        """
         # Filter watched items
         filtered_start_time = datetime.datetime.now()
         fallback_recommendations = self._filter_watched_items(
@@ -64,6 +78,10 @@ class FallbackRecommendationEngine(RecommendationEngine):
         filtered_watched_items_time = (
             datetime.datetime.now() - filtered_start_time
         ).total_seconds()
+
+        # logger.info(
+        #     f"Fallback output after watched filtering:\n\n {fallback_recommendations}"
+        # )
 
         # Filter reported items
         filtered_reported_items_start_time = datetime.datetime.now()

--- a/src/utils/valkey_utils.py
+++ b/src/utils/valkey_utils.py
@@ -554,6 +554,33 @@ class ValkeyService:
             logger.error(f"Failed to scan set {key} in {self.instance_id}: {e}")
             raise
 
+    def sdiff(self, *keys: str) -> Set[str]:
+        """Return the difference between the first set and the other sets"""
+        try:
+            client = self.get_client()
+            return client.sdiff(*keys)
+        except Exception as e:
+            logger.error(f"Failed to compute set difference for keys {keys} in {self.instance_id}: {e}")
+            raise
+
+    def sinter(self, *keys: str) -> Set[str]:
+        """Return the intersection of all sets"""
+        try:
+            client = self.get_client()
+            return client.sinter(*keys)
+        except Exception as e:
+            logger.error(f"Failed to compute set intersection for keys {keys} in {self.instance_id}: {e}")
+            raise
+
+    def sunion(self, *keys: str) -> Set[str]:
+        """Return the union of all sets"""
+        try:
+            client = self.get_client()
+            return client.sunion(*keys)
+        except Exception as e:
+            logger.error(f"Failed to compute set union for keys {keys} in {self.instance_id}: {e}")
+            raise
+
     # Redis Sorted Set Operations
     def zadd(self, key: str, mapping: Dict[str, float]) -> int:
         """Add one or more members to a sorted set, or update scores"""


### PR DESCRIPTION
Implement new Redis SET-based filtering for realtime watch history while maintaining existing zset scanning method for backward compatibility.

Key changes:
- Add filter_recommendations_using_sets() method with O(1) Redis SDIFF operations
- Implement combined filtering approach using both SET and zset methods
- Add required Redis set operations (sdiff, sinter, sunion) to ValkeyService
- Update HistoryManager to always use both filtering methods together
- Add comprehensive logging for filtering performance tracking
- Include fallback mechanisms for graceful degradation

The new SET method serves as an additional optimization layer rather than a replacement, ensuring robust filtering with multiple data sources.